### PR TITLE
FIX: The text meters does not show its values

### DIFF
--- a/iris/src/dfi/Posts/TotalAnnouncement.pivot.xml
+++ b/iris/src/dfi/Posts/TotalAnnouncement.pivot.xml
@@ -9,7 +9,7 @@
   <filter spec="[PostType].[H1].[PostType].&amp;[Announcement]" key="Announcement" value="" text="Announcement" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </filter>
   <sqlRestriction></sqlRestriction>
-  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
+  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="Announcement" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </measure>
 </pivot>
 </Document></Export>

--- a/iris/src/dfi/Posts/TotalArticles.pivot.xml
+++ b/iris/src/dfi/Posts/TotalArticles.pivot.xml
@@ -9,7 +9,7 @@
   <filter spec="[PostType].[H1].[PostType].&amp;[Article]" key="Article" value="" text="Article" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </filter>
   <sqlRestriction></sqlRestriction>
-  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
+  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="Article" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </measure>
 </pivot>
 </Document></Export>

--- a/iris/src/dfi/Posts/TotalDiscussion.pivot.xml
+++ b/iris/src/dfi/Posts/TotalDiscussion.pivot.xml
@@ -9,7 +9,7 @@
   <filter spec="[PostType].[H1].[PostType].&amp;[Discussion]" key="Discussion" value="" text="Discussion" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </filter>
   <sqlRestriction></sqlRestriction>
-  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
+  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="Discussion" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </measure>
 </pivot>
 </Document></Export>

--- a/iris/src/dfi/Posts/TotalPosts.pivot.xml
+++ b/iris/src/dfi/Posts/TotalPosts.pivot.xml
@@ -7,7 +7,7 @@
   <columnAxisOptions spec="" key="" value="" text="" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </columnAxisOptions>
   <sqlRestriction></sqlRestriction>
-  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
+  <measure spec="[Measures].[Posts]" key="" value="" text="Posts" headEnabled="false" headCount="" filterEnabled="false" filterExpression="" orderEnabled="false" orderExpression="" orderDirection="BDESC" aggEnabled="false" aggFunction="" aggFunctionParm="" levelCaption="Posts" levelFormat="#,###" levelSummary="" levelType="" drillLevel="0" advanced="false" levelStyle="" levelHeaderStyle="" suppress8020="false" drilldownSpec="" enabled="true">
   </measure>
 </pivot>
 </Document></Export>


### PR DESCRIPTION
Изменения в последнем релизе mdx2json затронули способ создания пивотов. Теперь необходимо указывать заголовок измерителя для корректного отображения. Он не может быть пустым.
Связанный issue
https://github.com/intersystems-community/analytics-dashboars/issues/207